### PR TITLE
Add a feature for enabling compilation for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ homepage = "https://github.com/dfrg/zeno"
 readme = "README.md"
 
 [dependencies]
+libm = { version = "0.2.7", default-features = false, optional = true }
 
 [features]
-default = ["eval"]
+default = ["eval", "std"]
 eval = []
+std = []
+

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,5 +1,7 @@
 //! Geometric primitives.
 
+use crate::F32Ext;
+
 use core::borrow::Borrow;
 use core::ops::{Add, Div, Mul, Sub};
 

--- a/src/path_builder.rs
+++ b/src/path_builder.rs
@@ -2,6 +2,7 @@
 
 use super::command::Command;
 use super::geometry::{Angle, BoundsBuilder, Point, Transform};
+use super::F32Ext;
 
 use crate::lib::Vec;
 

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -2,6 +2,7 @@
 
 use super::command::Command;
 use super::geometry::*;
+use super::F32Ext;
 
 use core::borrow::Borrow;
 


### PR DESCRIPTION
This commit adds two new features: "std" (which is enabled by default) and "libm". When "std" is enabled, floating point intrinsics are used from libstd. When "libm" is enabled, it brings in the pure Rust libm implementation to handle floating point instrinsics in software mode.

By disabling the "std" feature and enabling "libm", this crate can be effectively used on no_std platforms, like embedded systems.

This is a breaking change, as it adds an "std" default feature that, when disabled without enabling "libm", causes a compile error. Users who are currently using zeno with "default-features = false" without preparation will have their compilation break.

Rel: https://github.com/dfrg/swash/issues/4