### PR TITLE
Tighten bounds calculations and update `Mask::offset` documentation

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -481,8 +481,8 @@ impl Placement {
         let mut bounds = *bounds;
         bounds.min = (bounds.min + offset).floor();
         bounds.max = (bounds.max + offset).ceil();
-        let offset = Vector::new(-bounds.min.x + 1., -bounds.min.y);
-        let width = bounds.width() as u32 + 2;
+        let offset = Vector::new(-bounds.min.x, -bounds.min.y);
+        let width = bounds.width() as u32;
         let height = bounds.height() as u32;
         let left = -offset.x as i32;
         let top = if origin == Origin::BottomLeft {

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -130,7 +130,9 @@ where
         self
     }
 
-    /// Sets the offset for the path.
+    /// Sets the offset for the path's rendered bounds. To translate both the
+    /// path and its rendered bounding box, set both [`Self::offset`] and
+    /// [`Self::render_offset`].
     pub fn offset(&mut self, offset: impl Into<Vector>) -> &mut Self {
         self.offset = offset.into();
         self

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -233,8 +233,8 @@ where
             };
             bounds.min = (bounds.min + self.offset).floor();
             bounds.max = (bounds.max + self.offset).ceil();
-            offset = Vector::new(-bounds.min.x + 1., -bounds.min.y);
-            placement.width = bounds.width() as u32 + 2;
+            offset = Vector::new(-bounds.min.x, -bounds.min.y);
+            placement.width = bounds.width() as u32;
             placement.height = bounds.height() as u32;
         } else {
             offset = self.bounds_offset;


### PR DESCRIPTION
While integrating Parley with egui, I noticed a lot of extra padding around the glyphs' bounding boxes, and traced it back here. It seems the placement computation was deliberately padding the bounds horizontally. I can take an educated guess as to what might've caused this:

- Swash renders glyphs by passing the `render_offset` option into `zeno::Mask`. It doesn't use the `offset` option because, despite what the documentation says, it did not actually affect the rendered position of the path, just the bounding box.
- However, since `render_offset` doesn't adjust the bounds, glyphs were being cut off as they were shifted horizontally.
- To fix this, the bounds were unconditionally expanded by a few pixels horizontally.

~~I've changed the `offset` option in `Mask` to affect both the bounds' offset and the rendered path's position. This is a breaking change--I could also just change the code up in Swash to pass the same value for both `offset` and `render_offset`. Either way, this'll require a change in Swash, but I think it's clearer to have `offset` do what it says on the tin. It's your call.~~

(EDIT: Went with the more conservative option for now; see comment)

With that working properly, there is no reason for the bounds to be padded anymore. Here's a comparison:

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/0054185f-37cb-4f0a-a798-8d3fa33e4d12) | ![image](https://github.com/user-attachments/assets/7fcd26d4-b4d6-4d2d-8733-79363ed24b75) |

As an added bonus, this fixes the glyphs being vertically cut off in the Parley `swash_render` example, since vertical bounds were not being similarly padded here:

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/2b6cb7f3-4599-40ab-bc50-9d1b6d79abb8) | ![image](https://github.com/user-attachments/assets/a0fec8a5-6fe5-413a-b023-6ceb827761f2) |